### PR TITLE
fix: use libdtkcore-bin replace old deepin-qt5config

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends:
  qtbase5-dev,
  pkg-kde-tools,
  qtbase5-private-dev,
- deepin-qt5config
+ libdtkcore-bin
 Standards-Version: 4.1.1
 Homepage: https://github.com/linuxdeepin/dde-qt-dbus-factory
 


### PR DESCRIPTION
https://github.com/linuxdeepin/dtkcore/issues/17