### PR TITLE
fix: QVariant should be created with QMetaProperty::userType()

### DIFF
--- a/libdframeworkdbus/qtdbusextended/dbusextendedabstractinterface.cpp
+++ b/libdframeworkdbus/qtdbusextended/dbusextendedabstractinterface.cpp
@@ -177,7 +177,7 @@ QVariant DBusExtendedAbstractInterface::internalPropGet(const char *propname, vo
     if (m_useCache) {
         int propertyIndex = metaObject()->indexOfProperty(propname);
         QMetaProperty metaProperty = metaObject()->property(propertyIndex);
-        return QVariant(metaProperty.type(), propertyPtr);
+        return QVariant(metaProperty.userType(), propertyPtr);
     }
 
     if (m_sync) {
@@ -233,7 +233,7 @@ QVariant DBusExtendedAbstractInterface::internalPropGet(const char *propname, vo
         }
 
         asyncProperty(propname);
-        return QVariant(metaProperty.type(), propertyPtr);
+        return QVariant(metaProperty.userType(), propertyPtr);
     }
 }
 


### PR DESCRIPTION
QMetaProperty::type() always returns QVariant::UserType for any user-defined
type. So QVariant of type id 1024(QVariant::UserType) is always created instead
of the right type whose type ID is returned from QMetaProperty::userType().
Creating QVariant with wrong type may crash the process.

Fixes RHBZ#1892710

Log: QVariant should be created with QMetaProperty::userType()
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>