### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,20 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-qt-dbus-factory.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-qt-dbus-factory.spec
+    - .packit.yaml
+
+upstream_package_name: dde-qt-dbus-factory
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-qt-dbus-factory
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"0,/Version:/ s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-qt-dbus-factory.spec"
+  post-upstream-clone: |
+    cp rpm/dde-qt-dbus-factory.spec rpm/deepin-qt-dbus-factory.spec
+

--- a/rpm/dde-qt-dbus-factory.spec
+++ b/rpm/dde-qt-dbus-factory.spec
@@ -1,21 +1,34 @@
 %global soname dframeworkdbus
 %global repo   dde-qt-dbus-factory
 
+%if 0%{?fedora}
+Name:           deepin-qt-dbus-factory
+%else
 Name:           dde-qt-dbus-factory
-Version:        5.2.0.0
-Release:        3
+%endif
+Version:        5.3.0.20
+Release:        1%{?fedora:%dist}
 Summary:        A repository stores auto-generated Qt5 dbus code
 # The entire source code is GPLv3+ except
 # libdframeworkdbus/qtdbusextended/ which is LGPLv2+
 License:        GPLv3+ and LGPLv2+
+%if 0%{?fedora}
+URL:            https://github.com/linuxdeepin/dde-qt-dbus-factory
+Source0:        %{url}/archive/%{version}/%{repo}-%{version}.tar.gz
+%else
 URL:            http://shuttle.corp.deepin.com/cache/repos/eagle/release-candidate/56qX566h6IGU6LCD5rWL6K-V6aqM6K-BMDUyMTQ5Mg/pool/main/d/dde-qt-dbus-factory/
 Source0:        %{name}_%{version}.orig.tar.xz
+%endif
 
-BuildRequires:  python3-devel
+BuildRequires:  python3
 BuildRequires:  pkgconfig(gl)
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Gui)
+%if 0%{?fedora}
+BuildRequires:  qt5-qtbase-private-devel
+%{?_qt5:Requires: %{_qt5}%{?_isa} = %{_qt5_version}}
+%endif
 
 %description
 A repository stores auto-generated Qt5 dbus code.
@@ -29,32 +42,27 @@ Requires:       cmake-filesystem
 Header files and libraries for %{name}.
 
 %prep
-%setup -q -n %{repo}-%{version}
+%autosetup -p1 -n %{repo}-%{version}
 sed -i "s/env python$/env python3/g" libdframeworkdbus/generate_code.py
 sed -i "s/python/python3/g" libdframeworkdbus/libdframeworkdbus.pro
 
 %build
 %qmake_qt5 LIB_INSTALL_DIR=%{_libdir}
-sed -i "s/python/python3/g" Makefile
 %make_build
 
 %install
 %make_install INSTALL_ROOT=%{buildroot}
 
-%post -p /sbin/ldconfig
-
-%postun -p /sbin/ldconfig
-
 %files
-#%doc README
+%doc README.md CHANGELOG.md technology-overview.md
 %license LICENSE
-%{_libdir}/lib%{soname}.so.*
+%{_libdir}/lib%{soname}.so.2*
 
 %files devel
 %{_includedir}/lib%{soname}-2.0/
 %{_libdir}/pkgconfig/%{soname}.pc
 %{_libdir}/lib%{soname}.so
-%{_libdir}/cmake/DFrameworkdbus/DFrameworkdbusConfig.cmake
+%{_libdir}/cmake/DFrameworkdbus/
 
 %changelog
 * Thu Jun 09 2020 uoser <uoser@uniontech.com> - 5.2.0.2-1


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log: Initial packit setup
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>