### PR TITLE
Use relative path instead of absolute path.

### DIFF
--- a/libdframeworkdbus/generate_code.py
+++ b/libdframeworkdbus/generate_code.py
@@ -7,7 +7,7 @@ import subprocess
 
 dirname = os.path.dirname
 abspath = os.path.abspath
-project_root = dirname(dirname(abspath(__file__)))
+project_root = "../"
 
 def get_xml_files():
     xml_dir = os.path.join(project_root, "xml")


### PR DESCRIPTION
When using an absolute path, it's likely to be unreproducible in Debian because it adds the build-path to the comment in the generated code when executing qdbusxml2cpp-fix command by generate_code.py.

More info: https://lintian.debian.org/tags/file-references-package-build-path
