### PR TITLE
fix: fix copy elision

### DIFF
--- a/libdframeworkdbus/types/linkinfolist.cpp
+++ b/libdframeworkdbus/types/linkinfolist.cpp
@@ -83,7 +83,7 @@ LinkInfo LinkInfo::fromJson(const QJsonObject &infoObject)
     info.m_p2pScanning = infoObject.value("P2PScanning").toBool();
     info.m_dbusPath = QDBusObjectPath(infoObject.value("Path").toString());
 
-    return std::move(info);
+    return info;
 }
 
 bool LinkInfo::operator==(const LinkInfo &what)

--- a/libdframeworkdbus/types/sinkinfolist.cpp
+++ b/libdframeworkdbus/types/sinkinfolist.cpp
@@ -83,7 +83,7 @@ SinkInfo SinkInfo::fromJson(const QJsonObject &infoObject)
     info.m_sinkPath = QDBusObjectPath(infoObject.value("Path").toString());
     info.m_linkPath = QDBusObjectPath(infoObject.value("LinkPath").toString());
 
-    return std::move(info);
+    return info;
 }
 
 bool SinkInfo::operator==(const SinkInfo &what)


### PR DESCRIPTION
Resolve: https://github.com/linuxdeepin/developer-center/issues/3390
in this, use std::move will invalidate the copy elision optimization

Signed-off-by: Han Gao <rabenda.cn@gmail.com>