### PR TITLE
changelog: use native version insteadof quilt version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-dde-qt-dbus-factory (0.4.2-2) unstable; urgency=medium
+dde-qt-dbus-factory (0.4.2) unstable; urgency=medium
 
   * Refresh symbols using build's buildlog.
 


### PR DESCRIPTION
Log: use native version insteadof quilt version

Signed-off-by: Han Gao <rabenda.cn@gmail.com>